### PR TITLE
15.3 | React Tests

### DIFF
--- a/src/services/pokedexDataTest.js
+++ b/src/services/pokedexDataTest.js
@@ -1,0 +1,202 @@
+const allPokemons = [
+  {
+    id: 25,
+    name: 'Pikachu',
+    type: 'Electric',
+    averageWeight: {
+      value: '6.0',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/b/b2/Spr_5b_025_m.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Pikachu_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Kanto Viridian Forest',
+        map: 'https://cdn.bulbagarden.net/upload/0/08/Kanto_Route_2_Map.png',
+      },
+      {
+        location: 'Kanto Power Plant',
+        map: 'https://cdn.bulbagarden.net/upload/b/bd/Kanto_Celadon_City_Map.png',
+      },
+    ],
+    summary: 'This intelligent Pokémon roasts hard berries with electricity to make them tender enough to eat.',
+  },
+  {
+    id: 4,
+    name: 'Charmander',
+    type: 'Fire',
+    averageWeight: {
+      value: '8.5',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/0/0a/Spr_5b_004.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Charmander_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Alola Route 3',
+        map: 'https://cdn.bulbagarden.net/upload/9/93/Alola_Route_3_Map.png',
+      },
+      {
+        location: 'Kanto Route 3',
+        map: 'https://cdn.bulbagarden.net/upload/4/4a/Kanto_Route_3_Map.png',
+      },
+      {
+        location: 'Kanto Route 4',
+        map: 'https://cdn.bulbagarden.net/upload/2/24/Kanto_Route_4_Map.png',
+      },
+      {
+        location: 'Kanto Rock Tunnel',
+        map: 'https://cdn.bulbagarden.net/upload/6/6f/Kanto_Rock_Tunnel_Map.png',
+      },
+    ],
+    summary: 'The flame on its tail shows the strength of its life force. If it is weak, the flame also burns weakly.',
+  },
+  {
+    id: 10,
+    name: 'Caterpie',
+    type: 'Bug',
+    averageWeight: {
+      value: '2.9',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/8/83/Spr_5b_010.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Caterpie_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Johto Route 30',
+        map: 'https://cdn.bulbagarden.net/upload/7/76/Johto_Route_30_Map.png',
+      },
+      {
+        location: 'Johto Route 31',
+        map: 'https://cdn.bulbagarden.net/upload/2/2b/Johto_Route_31_Map.png',
+      },
+      {
+        location: 'Ilex Forest',
+        map: 'https://cdn.bulbagarden.net/upload/a/ae/Johto_Ilex_Forest_Map.png',
+      },
+      {
+        location: 'Johto National Park',
+        map: 'https://cdn.bulbagarden.net/upload/4/4e/Johto_National_Park_Map.png',
+      },
+    ],
+    summary: 'For protection, it releases a horrible stench from the antennae on its head to drive away enemies.',
+  },
+  {
+    id: 23,
+    name: 'Ekans',
+    type: 'Poison',
+    averageWeight: {
+      value: '6.9',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/1/18/Spr_5b_023.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Ekans_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Goldenrod Game Corner',
+        map: 'https://cdn.bulbagarden.net/upload/e/ec/Johto_Goldenrod_City_Map.png',
+      },
+    ],
+    summary: 'It can freely detach its jaw to swallow large prey whole. It can become too heavy to move, however.',
+  },
+  {
+    id: 65,
+    name: 'Alakazam',
+    type: 'Psychic',
+    averageWeight: {
+      value: '48.0',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/8/88/Spr_5b_065_m.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Alakazam_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Unova Accumula Town',
+        map: 'https://cdn.bulbagarden.net/upload/4/44/Unova_Accumula_Town_Map.png',
+      },
+    ],
+    summary: 'Closing both its eyes heightens all its other senses. This enables it to use its abilities to their extremes.',
+  },
+  {
+    id: 151,
+    name: 'Mew',
+    type: 'Psychic',
+    averageWeight: {
+      value: '4.0',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/4/43/Spr_5b_151.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Mew_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Faraway Island',
+        map: 'https://cdn.bulbagarden.net/upload/e/e4/Hoenn_Faraway_Island_Map.png',
+      },
+    ],
+    summary: 'Apparently, it appears only to those people who are pure of heart and have a strong desire to see it.',
+  },
+  {
+    id: 78,
+    name: 'Rapidash',
+    type: 'Fire',
+    averageWeight: {
+      value: '95.0',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/5/58/Spr_5b_078.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Rapidash_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Kanto Route 28',
+        map: 'https://cdn.bulbagarden.net/upload/5/5b/Kanto_Route_28_Map.png',
+      },
+      {
+        location: 'Johto Mount Silver',
+        map: 'https://cdn.bulbagarden.net/upload/9/95/Johto_Mt_Silver_Map.png',
+      },
+    ],
+    summary: 'At full gallop, its four hooves barely touch the ground because it moves so incredibly fast.',
+  },
+  {
+    id: 143,
+    name: 'Snorlax',
+    type: 'Normal',
+    averageWeight: {
+      value: '460.0',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/4/40/Spr_5b_143.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Snorlax_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Kanto Vermillion City',
+        map: 'https://cdn.bulbagarden.net/upload/5/54/Kanto_Vermilion_City_Map.png',
+      },
+    ],
+    summary: 'What sounds like its cry may actually be its snores or the rumblings of its hungry belly.',
+  },
+  {
+    id: 148,
+    name: 'Dragonair',
+    type: 'Dragon',
+    averageWeight: {
+      value: '16.5',
+      measurementUnit: 'kg',
+    },
+    image: 'https://cdn.bulbagarden.net/upload/2/2c/Spr_5b_148.png',
+    moreInfo: 'https://bulbapedia.bulbagarden.net/wiki/Dragonair_(Pok%C3%A9mon)',
+    foundAt: [
+      {
+        location: 'Johto Route 45',
+        map: 'https://cdn.bulbagarden.net/upload/2/21/Johto_Route_45_Map.png',
+      },
+      {
+        location: 'Johto Dragon\'s Den',
+        map: 'https://cdn.bulbagarden.net/upload/1/1e/Johto_Dragons_Den_Map.png',
+      },
+    ],
+    summary: 'They say that if it emits an aura from its whole body, the weather will begin to change instantly.',
+  },
+];
+
+export default allPokemons;


### PR DESCRIPTION
- [ ] 1 - Ao carregar a aplicação no caminho de URL “/”, a página principal da Pokédex deve ser mostrada.
- [ ] 2 - A Pokédex deve exibir apenas um pokémon por vez

- [ ] 3 - Ao apertar o botão de próximo, a página deve exibir o próximo pokémon da lista
O botão deve conter o texto Próximo pokémon;
Cliques sucessivos no botão devem mostrar o próximo pokémon da lista;
Ao se chegar ao último pokémon da lista, a Pokédex deve voltar para o primeiro pokémon no apertar do botão.

- [ ] 4 - A Pokédex deve conter botões de filtro
A partir da seleção de um botão de tipo, a Pokédex deve circular somente pelos pokémons daquele tipo;
O texto do botão deve ser o nome do tipo, p. ex. Psychic.

- [ ] 5 - A Pokédex deve conter um botão para resetar o filtro
O texto do botão deve ser All;
Após clicá-lo, a Pokédex deve voltar a circular por todos os pokémons;
Quando a página carrega, o filtro selecionado deve ser o All.

- [ ] 6 - A Pokédex deve gerar, dinamicamente, um botão de filtro para cada tipo de pokémon
Os botões de filtragem devem ser dinâmicos: sua Pokédex deve gerar um botão de filtragem para cada tipo de pokémon disponível nos dados independente de quais ou quantos sejam, sem repetição de tipos. Ou seja, se sua Pokédex possui pokémons do tipo Fire, Psychic, Electric e Normal, deve aparecer como opção de filtro um botão para cada um desses tipos. Além disso, ela deve manter o botão All.

- [ ] 7 - O botão de Próximo pokémon deve ser desabilitado se a lista filtrada de pokémons tiver um só pokémon

- [ ] 8 - A Pokedéx deve exibir o nome, tipo, peso médio e imagem do pokémon exibido
O peso médio do pokémon deve ser exibido com um texto no formato Average weight: <value> <measurementUnit>, onde <value> e <measurementUnit> são, respectivamente, o peso médio do pokémon e sua unidade de medida;
A imagem deve conter um atributo src com a URL da imagem do pokémon. A imagem deverá ter também um atributo alt com o nome do pokémon.

- [ ] 9 - O pokémon exibido na Pokedéx deve conter um link de navegação para exibir detalhes deste pokémon
O link deve possuir a URL /pokemons/<id>, onde <id> é o id do pokémon exibido.

- [ ] 10 - Ao clicar no link de navegação do pokémon, a aplicação deve ser redirecionada para a página de detalhes de pokémon
A URL exibida no navegador deve mudar para /pokemon/<id>, onde <id> é o id do pokémon cujos detalhes se deseja ver.

- [ ] 11 - A página de detalhes de pokémon deve exibir o nome, tipo, peso médio e imagem do pokémon exibido
O peso médio do pokémon deve ser exibido com um texto no formato Average weight: <value> <measurementUnit>, onde <value> e <measurementUnit> são, respectivamente, o peso médio do pokémon e sua unidade de medida;
A imagem deve conter um atributo src com a URL da imagem do pokémon. A imagem deverá ter também um atributo alt com o nome do pokémon.

- [ ] 12 - O pokémon exibido na página de detalhes não deve conter um link de navegação para exibir detalhes deste pokémon

- [ ] 13 - A página de detalhes deve exibir uma seção com um resumo do pokémon
A seção de detalhes deve conter um heading h2 com o texto Summary;
A seção de detalhes deve conter um parágrafo com o resumo do pokémon específico sendo visualizado.

- [ ] 14 - A página de detalhes deve exibir uma seção com os mapas com as localizações do pokémon
A seção de detalhes deve conter um heading h2 com o texto Game Locations of <pokémon>, onde <pokémon> é o nome do pokémon exibido;
A seção de detalhes deve exibir todas as localizações do pokémon;
Cada localização deve exibir o nome da localização e uma imagem do mapa da localização;
A imagem da localização deve ter um atributo src com a URL da localização;
A imagem da localização deve ter um atributo alt com o texto <name> location, onde <name> é o nome do pokémon.

- [ ] 15 - A página de detalhes deve permitir favoritar um pokémon
A página deve conter um checkbox que permita favoritar um pokémon. Cliques no checkbox devem, alternadadamente, adicionar e remover o pokémon da lista de favoritos;
O label do checkbox deve ser Pokémon favoritado?.

- [ ] 16 - Pokémons favoritados devem exibir um ícone de uma estrela
O ícone deve ser uma imagem, com o atributo src igual /star-icon.svg;
A imagem deve ter o atributo alt igual a <pokemon> is marked as favorite, onde <pokemon> é o nome do pokémon cujos detalhes estão sendo exibidos.

- [ ] 17 - No topo da aplicação, deve haver um conjunto fixo de links de navegação
O primeiro link deve possuir o texto Home com a URL /;
O segundo link deve possuir o texto About com a URL /about;
O terceiro link deve possuir o texto Favorite Pokémons com a URL /favorites.

- [ ] 18 - Ao clicar no link "Home" na barra de navegação, a aplicação deve ser redirecionada para a página inicial, na URL "/"

- [ ] 19 - Ao clicar no link "About" na barra de navegação, a aplicação deve ser redirecionada para a página de About, na URL "/about"

- [ ] 20 - Ao clicar no link "Favorite Pokémons" na barra de navegação, a aplicação deve ser redirecionada para a página de pokémons favoritados, na URL "/favorites"

- [ ] 21 - A página "About" deve exibir informações sobre a Pokédex
A página deve conter um heading h2 com o texto About Pokédex;
A página deve conter dois parágrafos com texto sobre a Pokédex;
A página deve conter a seguinte imagem de uma Pokédex: https://cdn.bulbagarden.net/upload/thumb/8/86/Gen_I_Pok%C3%A9dex.png/800px-Gen_I_Pok%C3%A9dex.png.

- [ ] 22 - A página de pokémon favoritos deve exibir os pokémons favoritos
A página deve exibir todos os pokémons favoritados;
A página não deve exibir nenhum pokémon não favoritado.

- [ ] 23 - Entrar em uma URL desconhecida exibe a página Not Found
A página deve conter um heading h2 com o texto Page requested not found 😭;
A página deve exibir a imagem https://media.giphy.com/media/kNSeTs31XBZ3G/giphy.gif.

- [ ] 24 - A cobertura de testes deve ser 100%
Para ver a cobertura de testes, execute no terminal o comando npm run test-coverage.

BÔNUS
A Pokédex é uma aplicação estática, com seus dados pré-definidos. Utilizando a PokéAPI, é possível deixá-la mais dinâmica e realista.
Implemente os requisitos propostos a seguir e escreva testes para eles. Tente manter sempre a cobertura de testes em 100%, garantindo assim que não há código ou fluxos lógicos não testados. Para um desafio adicional, tente utilizar TDD - escreva os testes à medida que for implementando os requisitos.

- [ ] 25 - Adicione uma rota para exibir uma lista de localizações
A URL da rota deve ser /locations;
A página deve exibir uma lista com as localizações retornadas pela PokéAPI. Você pode ler aqui e aqui como utilizar a PokéAPI para buscar uma lista de localizações.

- [ ] 26 - Adicione na barra de navegação um link para a lista de localizações
O link deve conter o texto Locations;
Ao clicar no link, a página com a lista de localizações deve ser exibida.

- [ ] 27 - Adicione botões de paginação na lista de localizações
Por default, os endpoints da PokéAPI retornam no máximo 20 resultados. Utilizando os parâmetros limit e offset, você pode especificar qual página deseja buscar e qual seu tamanho. Veja aqui como utilizar estes parâmetros.
Adicione dois botões "Anterior" e "Próxima" que permitam navegar entre as página da lista de localizações;
Na primeira página, o botão "Anterior" deve ser desabilitado. Da mesma forma, ao alcançar a última página, o botão "Próximo" deve ser desabilitado.

- [ ] 28 - Adiciona uma rota para exibir uma lista de gerações
A URL da rota deve ser /generations;
A página deve exibir uma lista com as gerações retornadas pela PokéAPI. Você pode ler aqui e aqui como utilizar a PokéAPI para buscar uma lista de gerações.

- [ ] 29 - Adicione na barra de navegação um link para a lista de gerações
O link deve conter o texto Generations;
Ao clicar no link, a página com a lista de gerações deve ser exibida.

- [ ] 30 - Adicione uma rota para exibir informações sobre uma geração
A URL da rota deve ser /generations/<id>, onde <id> é o id da geração exibida;
A página deve exibir, após buscar na PokéAPI, o nome da geração e uma lista com os nomes dos pokémons introduzidos nesta geração.

- [ ] 31 - Adicione a cada geração na lista de gerações um link para a página de detalhes desta geração
Ao clicar no link, a página com informações sobre a geração clicada deve ser exibida.